### PR TITLE
remove Craft/Yii API calls and use direct queries instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.0.7 - 2019-09-16
+### Fixed
+- Fixes issues with Crafts fields initialization and ElementQuery https://github.com/craftcms/cms/issues/4944
+
+
 ## 1.0.6 - 2019-07-21
 ### Improved
 - Fixes compatibility with Craft 3.2's new auto-saving drafts system

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "mmikkel/cp-field-inspect",
     "description": "Inspect field handles and easily edit field settings",
     "type": "craft-plugin",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "keywords": [
         "craft",
         "cms",

--- a/src/CpFieldInspect.php
+++ b/src/CpFieldInspect.php
@@ -208,7 +208,7 @@ class CpFieldInspect extends Plugin
                 ->all();
 
 
-            $data['fields'] = ArrayHelper::index($fields, 'id');
+            $data['fields'] = ArrayHelper::index($fields, 'handle');
             $view = Craft::$app->getView();
             $view->registerAssetBundle(CpFieldInspectBundle::class);
             $view->registerJs('Craft.CpFieldInspectPlugin.init(' . \json_encode($data) . ');');


### PR DESCRIPTION
When you call `Craft::$app->getFields()->getAllFields()` in your plugins while it's loaded because another plugin's field is initialized it will break the Elements fields because they can't be fetched properly. `Craft::$app->getUser()->getIsAdmin()` will try to fetch the user and select all **current** fields if a field with handle `aaa` exists your Plugin will be created due to Crafts behavior of doing things and you'll only be able to fetch a few fields instead of all

https://github.com/craftcms/cms/issues/4944
fixes #11